### PR TITLE
Adds VS static profiles

### DIFF
--- a/src/WeatherTwentyOne/Directory.Build.targets
+++ b/src/WeatherTwentyOne/Directory.Build.targets
@@ -5,5 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectCapability Include="MauiSingleProject" />
+
+    <!-- NOTE: Enable Static launch profiles on VS -->
+    <!--ProjectCapability Include="XamarinStaticLaunchProfiles" /-->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- This enable a fixed menu with the following values:

iOS Simulator
iOS Local Device
iOs Remote Device
Android Emulator
Android Local Device

- The active TargetFramework is automatically set when one of this profiles is selected
- The active debug target is automatically selected
- The default device for the current static profile is automatically selected
- Sub menu on start menu is enabled to change the selected device for the selected profile
- The devices are filtered depending of the selected profile

The capability was added to the file but it is not enabled, to enabled it you need to uncomment the line. 