### PR TITLE
update csproj with required PackageReferences

### DIFF
--- a/src/WeatherTwentyOne/WeatherTwentyOne.csproj
+++ b/src/WeatherTwentyOne/WeatherTwentyOne.csproj
@@ -43,8 +43,8 @@
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<!-- Required - WinUI does not yet have buildTransitive for everything -->
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
-		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.29-preview3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30" />
 		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.1" />
 		<PackageReference Include="PInvoke.User32" Version="0.7.104" />
 	</ItemGroup>


### PR DESCRIPTION
In the latest pre-release of Visual Studio (17.1 Preview 2) MAUI projects require the PackageReferences of Microsoft.WindowsAppSDK to be updated to 1.0.0 and Microsoft.Graphics.Win2D to 1.0.0.30