### PR TITLE
Tests out DI injection using DataTemplate

### DIFF
--- a/src/WeatherTwentyOne/Pages/HomePage.xaml.cs
+++ b/src/WeatherTwentyOne/Pages/HomePage.xaml.cs
@@ -9,8 +9,9 @@ namespace WeatherTwentyOne.Pages;
 public partial class HomePage : ContentPage
 {
     static bool isSetup = false;
+    private ITrayService _trayService;
 
-    public HomePage()
+    public HomePage(IEnumerable<ITrayService> trayServices)
     {
         InitializeComponent();
 
@@ -21,6 +22,7 @@ public partial class HomePage : ContentPage
             SetupAppActions();
             SetupTrayIcon();
         }
+        _trayService = trayServices.FirstOrDefault();
     }
 
     private void SetupAppActions()
@@ -43,12 +45,10 @@ public partial class HomePage : ContentPage
 
     private void SetupTrayIcon()
     {
-        var trayService = ServiceProvider.GetService<ITrayService>();
-
-        if (trayService != null)
+        if (_trayService != null)
         {
-            trayService.Initialize();
-            trayService.ClickHandler = () =>
+            _trayService.Initialize();
+            _trayService.ClickHandler = () =>
                 ServiceProvider.GetService<INotificationService>()
                     ?.ShowNotification("Hello Build! 😻 From .NET MAUI", "How's your weather?  It's sunny where we are 🌞");
         }

--- a/src/WeatherTwentyOne/WeatherTwentyOne.csproj
+++ b/src/WeatherTwentyOne/WeatherTwentyOne.csproj
@@ -43,8 +43,8 @@
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<!-- Required - WinUI does not yet have buildTransitive for everything -->
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
-		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.29-preview3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30" />
 		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.1" />
 		<PackageReference Include="PInvoke.User32" Version="0.7.104" />
 	</ItemGroup>


### PR DESCRIPTION
Tested out `ITrayService` service injection on `HomePage` which is set up using `DataTemplate` in `App.xaml`:

Link to code: [here](https://github.com/davidortinau/WeatherTwentyOne/blob/main/src/WeatherTwentyOne/App.xaml#L60-L73)
```xml
            <TabBar x:Name="PhoneTabs">
                <Tab Title="Home" Icon="tab_home.png">
                    <ShellContent ContentTemplate="{DataTemplate page:HomePage}"/>
                </Tab>
                <Tab Title="Favorites" Icon="tab_favorites.png">
                    <ShellContent ContentTemplate="{DataTemplate page:FavoritesPage}"/>
                </Tab>
                <Tab Title="Map" Icon="tab_map.png">
                    <ShellContent ContentTemplate="{DataTemplate page:MapPage}"/>
                </Tab>
                <Tab Title="Settings" Icon="tab_settings.png">
                    <ShellContent ContentTemplate="{DataTemplate page:SettingsPage}"/>
                </Tab>
            </TabBar>
```

Opened the PR just for reference. Will leave it up to @davidortinau to decide if they would like it merged into the app code.

/cc @PureWeen